### PR TITLE
created postgresql db and table with all toronto data

### DIFF
--- a/database_creation.ipynb
+++ b/database_creation.ipynb
@@ -1,0 +1,585 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Import dependencies\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "pd.set_option('max_colwidth', 400)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Read CSV files with the Toronto listings data\n",
+    "df_1 = pd.read_csv('data/listings_toronto_type1_pages001-162_2024-01-30.csv')\n",
+    "df_2 = pd.read_csv('data/listings_toronto_type2_pages001-016_2024-01-30.csv')\n",
+    "df_3 = pd.read_csv('data/listings_toronto_type3_pages001-015_2024-01-30.csv')\n",
+    "df_4 = pd.read_csv('data/listings_toronto_type5_pages001-050_2024-01-30.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>url</th>\n",
+       "      <th>address</th>\n",
+       "      <th>price</th>\n",
+       "      <th>baths</th>\n",
+       "      <th>beds</th>\n",
+       "      <th>dens</th>\n",
+       "      <th>street</th>\n",
+       "      <th>neighbourhood</th>\n",
+       "      <th>mls_id</th>\n",
+       "      <th>city</th>\n",
+       "      <th>property_type</th>\n",
+       "      <th>date_scraped</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>https://toronto.listing.ca/286-main-st-911.E8018446.htm#42-1</td>\n",
+       "      <td>286 Main St 911</td>\n",
+       "      <td>619900</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Main St</td>\n",
+       "      <td>East End-Danforth</td>\n",
+       "      <td>E8018446</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>https://toronto.listing.ca/215-queen-st-606.C7266728.htm#42-2</td>\n",
+       "      <td>215 Queen St 606</td>\n",
+       "      <td>529000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Queen St</td>\n",
+       "      <td>Waterfront Communities C1</td>\n",
+       "      <td>C7266728</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>https://toronto.listing.ca/10-park-lawn-rd-1408.W7239426.htm#42-3</td>\n",
+       "      <td>10 Park Lawn Rd 1408</td>\n",
+       "      <td>624900</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Park Lawn Rd</td>\n",
+       "      <td>Mimico</td>\n",
+       "      <td>W7239426</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>https://toronto.listing.ca/665-queen-st-402.E8030950.htm#42-4</td>\n",
+       "      <td>665 Queen St 402</td>\n",
+       "      <td>899900</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Queen St</td>\n",
+       "      <td>South Riverdale</td>\n",
+       "      <td>E8030950</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>https://toronto.listing.ca/1190-dundas-st-925.E8030860.htm#42-5</td>\n",
+       "      <td>1190 Dundas St 925</td>\n",
+       "      <td>599900</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Dundas St</td>\n",
+       "      <td>South Riverdale</td>\n",
+       "      <td>E8030860</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                 url  \\\n",
+       "0       https://toronto.listing.ca/286-main-st-911.E8018446.htm#42-1   \n",
+       "1      https://toronto.listing.ca/215-queen-st-606.C7266728.htm#42-2   \n",
+       "2  https://toronto.listing.ca/10-park-lawn-rd-1408.W7239426.htm#42-3   \n",
+       "3      https://toronto.listing.ca/665-queen-st-402.E8030950.htm#42-4   \n",
+       "4    https://toronto.listing.ca/1190-dundas-st-925.E8030860.htm#42-5   \n",
+       "\n",
+       "                address   price  baths  beds  dens        street  \\\n",
+       "0       286 Main St 911  619900      1     1     1       Main St   \n",
+       "1      215 Queen St 606  529000      1     1     0      Queen St   \n",
+       "2  10 Park Lawn Rd 1408  624900      1     1     1  Park Lawn Rd   \n",
+       "3      665 Queen St 402  899900      2     2     0      Queen St   \n",
+       "4    1190 Dundas St 925  599900      1     1     0     Dundas St   \n",
+       "\n",
+       "               neighbourhood    mls_id     city    property_type date_scraped  \n",
+       "0          East End-Danforth  E8018446  Toronto  condo_apartment   2024-01-30  \n",
+       "1  Waterfront Communities C1  C7266728  Toronto  condo_apartment   2024-01-30  \n",
+       "2                     Mimico  W7239426  Toronto  condo_apartment   2024-01-30  \n",
+       "3            South Riverdale  E8030950  Toronto  condo_apartment   2024-01-30  \n",
+       "4            South Riverdale  E8030860  Toronto  condo_apartment   2024-01-30  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Concatenate dataframes\n",
+    "df = pd.concat([df_1, df_2, df_3, df_4], axis = 0)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4819\n",
+      "4819\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Check DF lengths to make sure no rows were lost\n",
+    "print(len(df_1) + len(df_2) + len(df_3) + len(df_4))\n",
+    "print(len(df))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mls_id</th>\n",
+       "      <th>property_type</th>\n",
+       "      <th>address</th>\n",
+       "      <th>street</th>\n",
+       "      <th>neighbourhood</th>\n",
+       "      <th>city</th>\n",
+       "      <th>price</th>\n",
+       "      <th>baths</th>\n",
+       "      <th>beds</th>\n",
+       "      <th>dens</th>\n",
+       "      <th>date_scraped</th>\n",
+       "      <th>url</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>E8018446</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>286 Main St 911</td>\n",
+       "      <td>Main St</td>\n",
+       "      <td>East End-Danforth</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>619900</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "      <td>https://toronto.listing.ca/286-main-st-911.E8018446.htm#42-1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>C7266728</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>215 Queen St 606</td>\n",
+       "      <td>Queen St</td>\n",
+       "      <td>Waterfront Communities C1</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>529000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "      <td>https://toronto.listing.ca/215-queen-st-606.C7266728.htm#42-2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>W7239426</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>10 Park Lawn Rd 1408</td>\n",
+       "      <td>Park Lawn Rd</td>\n",
+       "      <td>Mimico</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>624900</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "      <td>https://toronto.listing.ca/10-park-lawn-rd-1408.W7239426.htm#42-3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>E8030950</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>665 Queen St 402</td>\n",
+       "      <td>Queen St</td>\n",
+       "      <td>South Riverdale</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>899900</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "      <td>https://toronto.listing.ca/665-queen-st-402.E8030950.htm#42-4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>E8030860</td>\n",
+       "      <td>condo_apartment</td>\n",
+       "      <td>1190 Dundas St 925</td>\n",
+       "      <td>Dundas St</td>\n",
+       "      <td>South Riverdale</td>\n",
+       "      <td>Toronto</td>\n",
+       "      <td>599900</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2024-01-30</td>\n",
+       "      <td>https://toronto.listing.ca/1190-dundas-st-925.E8030860.htm#42-5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     mls_id    property_type               address        street  \\\n",
+       "0  E8018446  condo_apartment       286 Main St 911       Main St   \n",
+       "1  C7266728  condo_apartment      215 Queen St 606      Queen St   \n",
+       "2  W7239426  condo_apartment  10 Park Lawn Rd 1408  Park Lawn Rd   \n",
+       "3  E8030950  condo_apartment      665 Queen St 402      Queen St   \n",
+       "4  E8030860  condo_apartment    1190 Dundas St 925     Dundas St   \n",
+       "\n",
+       "               neighbourhood     city   price  baths  beds  dens date_scraped  \\\n",
+       "0          East End-Danforth  Toronto  619900      1     1     1   2024-01-30   \n",
+       "1  Waterfront Communities C1  Toronto  529000      1     1     0   2024-01-30   \n",
+       "2                     Mimico  Toronto  624900      1     1     1   2024-01-30   \n",
+       "3            South Riverdale  Toronto  899900      2     2     0   2024-01-30   \n",
+       "4            South Riverdale  Toronto  599900      1     1     0   2024-01-30   \n",
+       "\n",
+       "                                                                 url  \n",
+       "0       https://toronto.listing.ca/286-main-st-911.E8018446.htm#42-1  \n",
+       "1      https://toronto.listing.ca/215-queen-st-606.C7266728.htm#42-2  \n",
+       "2  https://toronto.listing.ca/10-park-lawn-rd-1408.W7239426.htm#42-3  \n",
+       "3      https://toronto.listing.ca/665-queen-st-402.E8030950.htm#42-4  \n",
+       "4    https://toronto.listing.ca/1190-dundas-st-925.E8030860.htm#42-5  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Rearrange columns\n",
+    "df = df[['mls_id', 'property_type', 'address', 'street', 'neighbourhood', 'city', 'price', 'baths', 'beds', 'dens', 'date_scraped', 'url']]\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4819"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Check the mls_id column to ensure there are no duplicates\n",
+    "df['mls_id'].nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "condo_apartment       3226\n",
+       "detached_home          990\n",
+       "freehold _townhome     306\n",
+       "condo_townhome         297\n",
+       "Name: property_type, dtype: int64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Check the value counts of property type\n",
+    "df['property_type'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "condo_apartment      3226\n",
+       "detached_home         990\n",
+       "freehold_townhome     306\n",
+       "condo_townhome        297\n",
+       "Name: property_type, dtype: int64"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Fix the 'freehold _townhome' values in the property type column\n",
+    "value_to_replace = {'freehold _townhome': 'freehold_townhome'}\n",
+    "df['property_type'] = df['property_type'].replace(value_to_replace)\n",
+    "\n",
+    "#Check value counts again\n",
+    "df['property_type'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "mls_id           object\n",
+       "property_type    object\n",
+       "address          object\n",
+       "street           object\n",
+       "neighbourhood    object\n",
+       "city             object\n",
+       "price             int64\n",
+       "baths             int64\n",
+       "beds              int64\n",
+       "dens              int64\n",
+       "date_scraped     object\n",
+       "url              object\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Check data types\n",
+    "df.dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Database Creation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'user': 'postgres',\n",
+       " 'dbname': 'postgres',\n",
+       " 'host': 'localhost',\n",
+       " 'port': '5432',\n",
+       " 'tty': '',\n",
+       " 'options': '',\n",
+       " 'sslmode': 'prefer',\n",
+       " 'sslcompression': '0',\n",
+       " 'gssencmode': 'prefer',\n",
+       " 'krbsrvname': 'postgres',\n",
+       " 'target_session_attrs': 'any'}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Import dependencies to automate database creation in PostgreSQL\n",
+    "import sqlalchemy\n",
+    "import psycopg2\n",
+    "\n",
+    "#Connect to PostgreSQL and create database called listings_db\n",
+    "con = psycopg2.connect(user = 'postgres',\n",
+    "                       host = 'localhost',\n",
+    "                       port = '5432',\n",
+    "                       password = 'postgres')\n",
+    "\n",
+    "con.autocommit = True\n",
+    "cursor = con.cursor()\n",
+    "sql = '''CREATE DATABASE listings_db'''\n",
+    "cursor.execute(sql)\n",
+    "con.get_dsn_parameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Import modules from SQLalchemy\n",
+    "from sqlalchemy import Column, Date, String, Float, Integer \n",
+    "\n",
+    "#Engine connection to listings_db\n",
+    "engine = sqlalchemy.create_engine('postgresql://postgres:postgres@localhost:5432/listings_db')\n",
+    "\n",
+    "#Create table called toronto_listings from dataframe 'df' \n",
+    "df.to_sql(\n",
+    "    'toronto_listings', \n",
+    "    engine,\n",
+    "    if_exists='replace',\n",
+    "    index=False,\n",
+    "    chunksize=500,\n",
+    "    dtype={\"mls_id\": String(100),\n",
+    "           \"property_type\": String(100),\n",
+    "           \"address\": String(100),\n",
+    "           \"street\": String(100),\n",
+    "           \"neighbourhood\": String(100),\n",
+    "           \"city\": String(100),\n",
+    "           \"price\": Integer,\n",
+    "           \"baths\": Integer,\n",
+    "           \"beds\": Integer,\n",
+    "           \"dens\": Integer,\n",
+    "           \"date_scraped\": Date,\n",
+    "           \"url\": String(100)\n",
+    "    })\n",
+    "\n",
+    "#Alter table to set mls_id as the primary key\n",
+    "with engine.connect() as con:\n",
+    "    con.execute('ALTER TABLE toronto_listings ADD PRIMARY KEY (\"mls_id\")')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Close the connection to the PostgreSQL engine\n",
+    "con.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Note: File should only be ran once locally as the database creation cell will fail if the DB already exists.
Read the four Toronto listing CSV files into pandas dataframes and concatenated them into one DF. Rearranged the column order and fixed a whitespace in the property_type column (freehold _townhome vs freehold_townhome). Used SQLalchemy and psycopg2 to connect to postgreSQL, create a database called listings_db, and read the DF into a table called toronto_listings using df.to_sql. Also altered the table to set mls_id as the primary key before closing the connection.